### PR TITLE
Reference Python 3 explicitly

### DIFF
--- a/util/enron2sqlite.sh
+++ b/util/enron2sqlite.sh
@@ -1,2 +1,2 @@
-python enron2sqlite.py | pv | sqlite3 ../enron.db
+python3 enron2sqlite.py | pv | sqlite3 ../enron.db
 cat post_process.sql | sqlite3 ../enron.db


### PR DESCRIPTION
My Ubuntu 22.04 doesn't ship `python` symlink. Only `python3`.

In the meantime, found this package `python-is-python3` saying:

> Description-en: symlinks /usr/bin/python to python3
 Starting with the Debian 11 (bullseye) and Ubuntu 20.04 LTS (focal)
 releases, all python packages use explicit python3 or python2
 interpreter and do not use unversioned /usr/bin/python at all. Some
 third-party code is now predominantly python3 based, yet may use
 /usr/bin/python.
 .
 This is a convenience package which ships a symlink to point
 the /usr/bin/python interpreter at the current default python3. It may
 improve compatibility with other modern systems, whilst breaking some
 obsolete or 3rd-party software.

So OK, let's be explicit with `python3` then.